### PR TITLE
docs: zero-to-hero README + usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,120 @@
-# HiveMind - Flask Chat Room
+# HiveMind Flask Chatroom
 
 ![logo](./flask.png)
 
-A multi-user Flask chatroom template for [HiveMind](https://github.com/OpenJarbas/HiveMind-core).
+A multi-user Flask chatroom that connects to a [HiveMind](https://github.com/JarbasHiveMind/HiveMind-core)
+hub as a single satellite and fans it out to many browser users. Each visitor
+chats under their own username and language; messages are routed to your
+OpenVoiceOS assistant through the hub and spoken replies are streamed back into
+the room.
 
-This simple WebUI allows you to securely interact with your OpenVoiceOS instance through [HiveMind](https://github.com/OpenJarbas/HiveMind-core).
+![chatroom](./chatroom.png)
 
-![image](https://github.com/user-attachments/assets/2b75d944-25a1-4dac-887f-5aa8de7c840f)
+## Where it sits
 
-This is a reference implementation for integrating the HiveMind server-side without requiring users to provide credentials.
+HiveMind is a mesh: satellites connect to a central
+[hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core) hub over an
+authenticated, encrypted protocol. This app is **one** satellite — it holds a
+single set of HiveMind credentials and authenticates server-side using the
+Python [hivemind-bus-client](https://github.com/JarbasHiveMind/hivemind-websocket-client).
+Browser users never see or supply credentials; they just pick a name and talk.
 
-For client-side (JavaScript) connection, check out [HiveMind-webchat](https://github.com/OpenJarbas/HiveMind-webchat).
-
-## Installation
-
-Install the package using `pip`:
-
-```bash
-$ pip install hivemind-flask-chatroom
+```
+many browsers ──HTTP──► Flask app (1 HiveMind credential) ──encrypted──► hivemind-core ──► OVOS / agent
 ```
 
-## Running the Application
+This is the counterpart to [HiveMind-webchat](https://github.com/JarbasHiveMind/HiveMind-webchat),
+which connects **client-side** from each browser instead. Use this when you want
+a shared room where the credential lives on the server.
 
-To run the chatroom, use the following command:
+## Install
 
 ```bash
-$ hivemind-flask-chatroom --port 8985
+pip install hivemind-flask-chatroom
 ```
 
-> Note: HiveMind credentials are read from your identity file.
+Dependencies: `flask`, `hivemind-bus-client`.
+
+## Quickstart
+
+### 1. Run a hub and add this client
+
+On the machine hosting the assistant, install and run
+[hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core):
+
+```bash
+hivemind-core add-client      # prints an access key + password
+hivemind-core listen --port 5678
+```
+
+### 2. Provision the chatroom's identity
+
+The chatroom authenticates from the HiveMind **identity file** rather than CLI
+flags. Write the credentials from the previous step into it with the
+`hivemind-bus-client` CLI:
+
+```bash
+hivemind-client set-identity \
+  --key <access-key> \
+  --password <password> \
+  --host 127.0.0.1 --port 5678 \
+  --siteid flask
+```
+
+This populates `~/.config/hivemind/_identity.json`, which the app reads on
+startup. Verify it can reach the hub with `hivemind-client test-identity`.
+
+### 3. Start the chatroom
+
+```bash
+hivemind-flask-chatroom --port 8985
+```
+
+Open `http://localhost:8985`. You are redirected to a room as `anon_user`; to
+join under a specific name, language, or site, visit
+`/chatroom/<username>/<site_id>/<lang>` directly (for example
+`/chatroom/alice/livingroom/en`). Type a message and the assistant's reply
+appears prefixed with your username.
+
+## Command-line options
+
+```
+usage: hivemind-flask-chatroom [-h] [--port PORT] [--host HOST]
+                               [--log-level LOG_LEVEL] [--log-path LOG_PATH]
+
+options:
+  -h, --help            show this help message and exit
+  --port PORT           Chatroom port (default 8985)
+  --host HOST           Bind address (default 0.0.0.0)
+  --log-level LOG_LEVEL DEBUG / INFO / ERROR (default DEBUG)
+  --log-path LOG_PATH   Log directory; default <xdg_state>/hivemind,
+                        or "stdout" to log to the console
+```
+
+## How it works
+
+- On startup `MessageHandler.connect()` opens one `HiveMessageBusClient`
+  (useragent `JarbasFlaskChatRoomV0.2`, `site_id="flask"`) to the hub and
+  subscribes to `speak`, `ovos.common_play.play`, and the legacy audio-play
+  message.
+- Each browser user maps to an OVOS `Session` keyed by username, so per-user
+  `lang` and `site_id` preferences persist across turns. Outgoing utterances
+  carry that session so skills can tell users apart.
+- Routes: `GET /` redirects into a room; `GET /chatroom/<username>/<site_id>/<lang>`
+  renders the room; `POST /send_message` submits an utterance; `GET /messages`
+  returns the running message log as JSON (the page polls it).
+
+The HiveMind link is end-to-end encrypted between the Flask process and the hub;
+the browser-to-Flask hop is plain HTTP, so front it with a TLS reverse proxy
+(nginx, Caddy) for any non-local deployment.
+
+## See also
+
+- [docs/usage.md](./docs/usage.md) — identity provisioning, multi-user routing,
+  and the message API in more detail.
+- [HiveMind-webchat](https://github.com/JarbasHiveMind/HiveMind-webchat) — the
+  browser-side single-user equivalent.
+
+## License
+
+Apache 2.0 — see [LICENSE](./LICENSE).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,82 @@
+# Usage guide
+
+This page covers identity provisioning, multi-user routing, and the HTTP message
+API. For install and the quickstart, see the [README](../README.md).
+
+## Identity provisioning
+
+The chatroom is a single HiveMind satellite. It does not take credentials on the
+command line; instead it reads the HiveMind **identity file** at
+`~/.config/hivemind/_identity.json`. Populate it once with the
+[`hivemind-bus-client`](https://github.com/JarbasHiveMind/hivemind-websocket-client)
+CLI using an access key from `hivemind-core add-client`:
+
+```bash
+hivemind-client set-identity \
+  --key <access-key> \
+  --password <password> \
+  --host 127.0.0.1 --port 5678 \
+  --siteid flask
+hivemind-client test-identity      # confirm it connects
+```
+
+`--host` may be a bare host or a `ws://` / `wss://` URL; a bare host is treated
+as `ws://`. The `--siteid` becomes the default `site_id` for the satellite.
+
+## Multi-user model
+
+A single `HiveMessageBusClient` carries traffic for every browser user. The app
+keeps one OVOS `Session` per username so skills can tell users apart and
+per-user preferences persist across turns:
+
+- `username` — identifies the speaker; the assistant's reply is shown as
+  `@<username> - <utterance>`.
+- `lang` — the language tag sent with each utterance (default `en`).
+- `site_id` — the location identifier placed in `message.context` (default
+  `flask`).
+
+These come from the room URL, so different users (or rooms) are just different
+paths:
+
+```
+/chatroom/alice/livingroom/en
+/chatroom/bob/kitchen/pt-pt
+```
+
+`GET /` redirects to `/chatroom/anon_user/flask/en`.
+
+## HTTP routes
+
+| Method | Route | Purpose |
+|--------|-------|---------|
+| `GET`  | `/` | Redirect into the default room |
+| `GET`  | `/chatroom/<username>/<site_id>/<lang>` | Render the chat room |
+| `POST` | `/send_message` | Submit an utterance (form fields: `username`, `lang`, `site_id`, `message`) |
+| `GET`  | `/messages` | Return the running message log as JSON; the page polls this |
+
+A `/messages` entry looks like:
+
+```json
+{ "incoming": true, "username": "HiveMind", "message": "@alice - the weather is sunny" }
+```
+
+`incoming: true` marks a message from the assistant; `false` marks a user line.
+
+## What the assistant sends back
+
+The satellite subscribes to three OVOS bus messages from the hub and appends
+them to the room log:
+
+- `speak` — spoken responses, shown as `@<user> - <utterance>`.
+- `ovos.common_play.play` — OCP media playback; the artist/title and URI are
+  printed as text (in-browser playback is left as an extension point).
+- `mycroft.audio.service.play` — legacy audio playback; track list printed as
+  text.
+
+## Deployment
+
+The browser-to-Flask hop is plain HTTP. For anything beyond local use, run the
+app behind a TLS reverse proxy (nginx, Caddy). The Flask-to-hub hop is always
+encrypted end to end by HiveMind, independent of the proxy. Logs default to
+`<xdg_state>/hivemind/flask-chat.log`; pass `--log-path stdout` to log to the
+console instead.


### PR DESCRIPTION
Expands the stub README into a full zero-to-hero guide: what the chatroom is and where it sits (a single server-side satellite fanning out to many browsers, contrasted with browser-side HiveMind-webchat), install, a quickstart that provisions the HiveMind identity file via `hivemind-client set-identity`, CLI options, the per-user session model, and the HTTP routes. Adds `docs/usage.md` covering identity provisioning, multi-user routing, the message API, and deployment. Also fixes stale `OpenJarbas` hub links to `JarbasHiveMind`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)