### PR TITLE
fix(deps): raise floor pins to the proven-working HiveMind stack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,37 +12,37 @@ requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
     "flask",
-    # hivemind-bus-client 0.9.x is the bus-client 2.x line; pin the pre-release
-    # floor so the resolver picks the 2.x-compatible alpha WITHOUT --pre. The
-    # app's runtime imports (ovos_bus_client.message/session, ovos_utils) come
-    # in transitively but are floored explicitly so the graph resolves on the
-    # ovos-bus-client 2.x world.
-    "hivemind-bus-client>=0.9.2a1,<1.0.0",
-    "ovos-bus-client>=2.0.0a3,<3.0.0",
-    "ovos-utils>=0.11.1a1,<1.0.0",
+    # hivemind-bus-client is the bus-client line; pin the pre-release floor
+    # so the resolver picks the compatible alpha WITHOUT --pre. The app's
+    # runtime imports (ovos_bus_client.message/session, ovos_utils) come in
+    # transitively but are floored explicitly so the graph resolves on the
+    # ovos-bus-client world.
+    "hivemind-bus-client>=1.0.16a1",
+    "ovos-bus-client>=2.9.1a1,<3.0.0",
+    "ovos-utils>=0.13.15a1,<1.0.0",
 ]
 
 [project.optional-dependencies]
 # End-to-end tests: a real hivemind-core master + this chatroom satellite over a
-# real HiveMessageBusClient, driven by the hivescope harness. The HiveMind 2.x
-# stack (core / agent-plugin / hivescope) requires ovos-bus-client>=2.0.0a3; the
+# real HiveMessageBusClient, driven by the hivescope harness. The HiveMind
+# stack (core / agent-plugin / hivescope) requires ovos-bus-client>=2.9.1a1; the
 # chatroom runtime floors the same pre-releases, so the whole graph resolves on
-# the 2.x world. hivemind-core's transitive pre-release floors (json-database /
+# the same world. hivemind-core's transitive pre-release floors (json-database /
 # hivemind-sqlite-database / hivemind-json-db-plugin / ovos-utils /
 # ovos-workshop) are restated here so uv/pip pick them WITHOUT --pre (a
 # pre-release min-version pin is enough).
 e2e = [
     "pytest",
     "pytest-timeout",
-    "hivescope>=0.5.2a1",
-    "hivemind-core>=4.6.2a1",
-    "hivemind-ovos-agent-plugin>=0.3.1a1",
-    "hivemind-plugin-manager>=0.8.0a1",
-    "json-database>=0.10.2a1",
-    "hivemind-sqlite-database>=0.4.0a2",
-    "hivemind-json-db-plugin>=0.0.3a2",
-    "hivemind-websocket-protocol>=0.0.3",
-    "ovos-utils>=0.11.1a1",
+    "hivescope>=0.8.0a1",
+    "hivemind-core>=4.13.18a1",
+    "hivemind-ovos-agent-plugin>=0.3.10a1",
+    "hivemind-plugin-manager>=0.9.0a7",
+    "json-database>=1.0.4a1",
+    "hivemind-sqlite-database>=0.4.3a5",
+    "hivemind-json-db-plugin>=0.0.4a7",
+    "hivemind-websocket-protocol>=0.2.9a1",
+    "ovos-utils>=0.13.15a1",
     "ovos-workshop>=8.0.0a1",
 ]
 # Back-compat alias: the shared CI workflows historically install the `test`

--- a/tests/e2e/test_bridge1_conformance.py
+++ b/tests/e2e/test_bridge1_conformance.py
@@ -21,6 +21,7 @@ from hivescope.assertions import (
     assert_source_stamped,
     assert_destination_routed,
     assert_session_inbound_preserved,
+    assert_session_id_natted,
     assert_session_outbound_preserved,
     assert_fifo_order,
     assert_session_propagated_unchanged,
@@ -169,10 +170,12 @@ def test_destination_routed():
 # ─────────────────────────────────────────────────────────────────────────────
 
 def test_session_inbound_preserved():
-    """Satellite's session fields are preserved into bus context.session.
+    """Satellite's session fields are preserved into bus context.session,
+    and its declared session_id is NATted to the connection's per-message
+    Layer-1 id (a non-admin's declared id is never used verbatim on the bus).
 
-    Spec: BRIDGE-1 §4.1 (inbound)
-    Helper: assert_session_inbound_preserved
+    Spec: BRIDGE-1 §4.1 (inbound) / §4 (per-connection session NAT)
+    Helpers: assert_session_inbound_preserved, assert_session_id_natted
     """
     b = _topology_with_utterance()
     b.start_all()
@@ -191,8 +194,9 @@ def test_session_inbound_preserved():
 
         assert_session_inbound_preserved(
             m, s,
-            expected_session={"session_id": sid, "lang": sess.serialize().get("lang")},
+            expected_session={"lang": sess.serialize().get("lang")},
         )
+        assert_session_id_natted(m, s, sid)
     finally:
         b.stop_all()
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

This raises the dependency floor pins in pyproject.toml to the combination of versions verified together in the live production HiveMind hub, and drops the stale `<1.0.0` upper cap on hivemind-bus-client, which excluded the entire current 1.0.x line — the main bug this fixes.

Pins changed (before -> after):
- hivemind-bus-client: >=0.9.2a1,<1.0.0 -> >=1.0.16a1 (cap dropped)
- ovos-bus-client: >=2.0.0a3,<3.0.0 -> >=2.9.1a1,<3.0.0 (existing cap kept, it is not stale against the new floor)
- ovos-utils: >=0.11.1a1,<1.0.0 -> >=0.13.15a1,<1.0.0 (cap kept, not stale)
- hivemind-core (e2e extra): >=4.6.2a1 -> >=4.13.18a1
- hivemind-ovos-agent-plugin (e2e extra): >=0.3.1a1 -> >=0.3.10a1
- hivemind-plugin-manager (e2e extra): >=0.8.0a1 -> >=0.9.0a7
- json-database (e2e extra): >=0.10.2a1 -> >=1.0.4a1
- hivemind-sqlite-database (e2e extra): >=0.4.0a2 -> >=0.4.3a5
- hivemind-json-db-plugin (e2e extra): >=0.0.3a2 -> >=0.0.4a7
- hivemind-websocket-protocol (e2e extra): >=0.0.3 -> >=0.2.9a1
- ovos-utils (e2e extra): >=0.11.1a1 -> >=0.13.15a1
- hivescope (e2e extra): >=0.5.2a1 -> >=0.8.0a1

`ovos-workshop` is not in the proven set and was left untouched. Comments referencing the old "0.9.x"/"4.6.x"/"2.x world" versions were updated. No new caps were added.

The vendored `tests/e2e/test_bridge1_conformance.py` is synced to the shipped session model: hivemind-core >=4.13.18a1 NATs a non-admin's declared `session_id` to `conn_nonce:declared` before it reaches the bus, and hivescope's `assert_session_inbound_preserved` now checks session CONTENTS only (it raises if passed `session_id`). The inbound test now asserts contents via `assert_session_inbound_preserved` and the NAT itself via the new `assert_session_id_natted(master, satellite, declared_id)`, which ships in hivescope 0.8.0a1.

Resolve proof: `uv pip install --prerelease=allow -e ".[e2e]"` in a fresh venv resolves cleanly against the new floors, including `hivescope 0.8.0a1` and `hivemind-core 4.13.18a1`.

e2e conformance (`tests/e2e/test_bridge1_conformance.py`): 8 passed, 1 skipped, 1 xpassed — all green. Before the conformance-test sync, `test_session_inbound_preserved` failed (old test asserted the verbatim inbound `session_id`, which the NAT no longer preserves).

This change aligns the chatroom satellite with the currently deployed `hivemind-core` 4.13.18a1 / `hivemind-bus-client` 1.0.16a1 / `hivescope` 0.8.0a1+ stack, so it can actually be installed and its e2e suite passes against the shipped session model.